### PR TITLE
Added wrapper for FLAC__stream_decoder_skip_single_frame() to pyflac

### DIFF
--- a/flac/decoder.i
+++ b/flac/decoder.i
@@ -229,9 +229,9 @@ PyObject *callbacks[3];
         return FLAC__stream_decoder_process_until_end_of_stream(self);
     }
 
-	FLAC__bool skip_single_frame() {
-		return FLAC__stream_decoder_skip_single_frame(self);
-	}
+    FLAC__bool skip_single_frame() {
+        return FLAC__stream_decoder_skip_single_frame(self);
+    }
 
     FLAC__bool seek_absolute(FLAC__uint64 sample) {
         return FLAC__stream_decoder_seek_absolute(self, sample);

--- a/flac/decoder.i
+++ b/flac/decoder.i
@@ -229,6 +229,10 @@ PyObject *callbacks[3];
         return FLAC__stream_decoder_process_until_end_of_stream(self);
     }
 
+	FLAC__bool skip_single_frame() {
+		return FLAC__stream_decoder_skip_single_frame(self);
+	}
+
     FLAC__bool seek_absolute(FLAC__uint64 sample) {
         return FLAC__stream_decoder_seek_absolute(self, sample);
     }


### PR DESCRIPTION
Hello Dan

I needed this functionality so I added the missing wrapper. Please pull.

BR / Klas
